### PR TITLE
Added Review to the Example

### DIFF
--- a/PlayCoreUpdateTest/PlayCoreUpdateTest.Android/InAppReviewRenderer.cs
+++ b/PlayCoreUpdateTest/PlayCoreUpdateTest.Android/InAppReviewRenderer.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Com.Google.Android.Play.Core.Tasks;
+using Com.Google.Android.Play.Core.Review;
+using Com.Google.Android.Play.Core.Review.Testing;
+
+[assembly: Xamarin.Forms.Dependency(typeof(PlayCoreUpdateTest.Droid.InAppReviewRenderer))]
+namespace PlayCoreUpdateTest.Droid
+{
+    public class InAppReviewRenderer : IInAppReview
+    {
+        public void LaunchReview()
+        {
+#if DEBUG
+            var manager = new FakeReviewManager(MainActivity.Instance);
+#else         
+            var manager = ReviewManagerFactory.Create(MainActivity.Instance);
+#endif            
+            var request = manager.RequestReviewFlow();
+            request.AddOnCompleteListener(new OnCompleteListener(manager));
+        }
+    }
+
+    public class OnCompleteListener : Java.Lang.Object, IOnCompleteListener
+    {
+        FakeReviewManager _fakeReviewManager;
+        IReviewManager _reviewManager;
+        bool _usesFakeManager;
+        void IOnCompleteListener.OnComplete(Com.Google.Android.Play.Core.Tasks.Task p0)
+        {
+            if (p0.IsSuccessful)
+            {
+                var review = p0.GetResult(Java.Lang.Class.FromType(typeof(ReviewInfo)));
+                if (_usesFakeManager)
+                {
+                    var x = _fakeReviewManager.LaunchReviewFlow(MainActivity.Instance, (ReviewInfo)review);
+                    x.AddOnCompleteListener(new OnCompleteListener(_fakeReviewManager));
+                }
+                else
+                {
+                    var x = _reviewManager.LaunchReviewFlow(MainActivity.Instance, (ReviewInfo)review);
+                    x.AddOnCompleteListener(new OnCompleteListener(_reviewManager));
+                }
+            }
+        }
+        public OnCompleteListener(FakeReviewManager fakeReviewManager)
+        {
+            _fakeReviewManager = fakeReviewManager;
+            _usesFakeManager = true;
+        }
+        public OnCompleteListener(IReviewManager reviewManager)
+        {
+            _reviewManager = reviewManager;
+        }
+    }
+}

--- a/PlayCoreUpdateTest/PlayCoreUpdateTest.Android/InAppReviewService.cs
+++ b/PlayCoreUpdateTest/PlayCoreUpdateTest.Android/InAppReviewService.cs
@@ -3,10 +3,10 @@ using Com.Google.Android.Play.Core.Tasks;
 using Com.Google.Android.Play.Core.Review;
 using Com.Google.Android.Play.Core.Review.Testing;
 
-[assembly: Xamarin.Forms.Dependency(typeof(PlayCoreUpdateTest.Droid.InAppReviewRenderer))]
+[assembly: Xamarin.Forms.Dependency(typeof(PlayCoreUpdateTest.Droid.InAppReviewService))]
 namespace PlayCoreUpdateTest.Droid
 {
-    public class InAppReviewRenderer : IInAppReview
+    public class InAppReviewService : IInAppReview
     {
         public void LaunchReview()
         {

--- a/PlayCoreUpdateTest/PlayCoreUpdateTest.Android/MainActivity.cs
+++ b/PlayCoreUpdateTest/PlayCoreUpdateTest.Android/MainActivity.cs
@@ -18,12 +18,14 @@ namespace PlayCoreUpdateTest.Droid
     [Activity(Label = "PlayCoreUpdateTest", Icon = "@mipmap/icon", Theme = "@style/MainTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
     public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompatActivity
     {
+        internal static MainActivity Instance { get; private set; }
         private const int _Request_Update = 4711;
         private const int APP_UPDATE_TYPE_SUPPORTED = AppUpdateType.Immediate;
         protected override void OnCreate(Bundle savedInstanceState)
         {
             TabLayoutResource = Resource.Layout.Tabbar;
             ToolbarResource = Resource.Layout.Toolbar;
+            Instance = this;
 
             base.OnCreate(savedInstanceState);
 

--- a/PlayCoreUpdateTest/PlayCoreUpdateTest.Android/PlayCoreUpdateTest.Android.csproj
+++ b/PlayCoreUpdateTest/PlayCoreUpdateTest.Android/PlayCoreUpdateTest.Android.csproj
@@ -16,6 +16,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
     <AndroidEnableSGenConcurrent>true</AndroidEnableSGenConcurrent>
     <AndroidUseAapt2>true</AndroidUseAapt2>
@@ -92,7 +93,7 @@
       <Name>PlayCore</Name>
     </ProjectReference>
     <ProjectReference Include="..\PlayCoreUpdateTest\PlayCoreUpdateTest.csproj">
-      <Project>{EC032212-8098-4BC1-ACAC-2425B0B67313}</Project>
+      <Project>{C645A9F0-2268-4164-9A15-429B63CF2A52}</Project>
       <Name>PlayCoreUpdateTest</Name>
     </ProjectReference>
   </ItemGroup>

--- a/PlayCoreUpdateTest/PlayCoreUpdateTest.Android/PlayCoreUpdateTest.Android.csproj
+++ b/PlayCoreUpdateTest/PlayCoreUpdateTest.Android/PlayCoreUpdateTest.Android.csproj
@@ -59,7 +59,7 @@
     <Compile Include="MainActivity.cs" />
     <Compile Include="Resources\Resource.designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="InAppReviewRenderer.cs" />
+    <Compile Include="InAppReviewService.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />

--- a/PlayCoreUpdateTest/PlayCoreUpdateTest.Android/PlayCoreUpdateTest.Android.csproj
+++ b/PlayCoreUpdateTest/PlayCoreUpdateTest.Android/PlayCoreUpdateTest.Android.csproj
@@ -61,6 +61,7 @@
     <Compile Include="MainActivity.cs" />
     <Compile Include="Resources\Resource.designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="InAppReviewRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />

--- a/PlayCoreUpdateTest/PlayCoreUpdateTest.Android/PlayCoreUpdateTest.Android.csproj
+++ b/PlayCoreUpdateTest/PlayCoreUpdateTest.Android/PlayCoreUpdateTest.Android.csproj
@@ -16,7 +16,6 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
     <AndroidEnableSGenConcurrent>true</AndroidEnableSGenConcurrent>
     <AndroidUseAapt2>true</AndroidUseAapt2>
@@ -35,8 +34,6 @@
     <AndroidLinkMode>None</AndroidLinkMode>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
@@ -95,7 +92,7 @@
       <Name>PlayCore</Name>
     </ProjectReference>
     <ProjectReference Include="..\PlayCoreUpdateTest\PlayCoreUpdateTest.csproj">
-      <Project>{C645A9F0-2268-4164-9A15-429B63CF2A52}</Project>
+      <Project>{EC032212-8098-4BC1-ACAC-2425B0B67313}</Project>
       <Name>PlayCoreUpdateTest</Name>
     </ProjectReference>
   </ItemGroup>

--- a/PlayCoreUpdateTest/PlayCoreUpdateTest/IInAppReview.cs
+++ b/PlayCoreUpdateTest/PlayCoreUpdateTest/IInAppReview.cs
@@ -1,8 +1,14 @@
 ﻿using System;
 namespace PlayCoreUpdateTest
 {
+    /// <summary>
+    /// Interface to provide in-review functionality
+    /// </summary>
     public interface IInAppReview
     {
+        /// <summary>
+        /// Function to launch the In-App Review
+        /// </summary>
         void LaunchReview();
     }
 }

--- a/PlayCoreUpdateTest/PlayCoreUpdateTest/IInAppReview.cs
+++ b/PlayCoreUpdateTest/PlayCoreUpdateTest/IInAppReview.cs
@@ -1,0 +1,8 @@
+﻿using System;
+namespace PlayCoreUpdateTest
+{
+    public interface IInAppReview
+    {
+        void LaunchReview();
+    }
+}

--- a/PlayCoreUpdateTest/PlayCoreUpdateTest/MainPage.xaml
+++ b/PlayCoreUpdateTest/PlayCoreUpdateTest/MainPage.xaml
@@ -11,6 +11,7 @@
         <Label Text="Welcome to Xamarin.Forms!" 
            HorizontalOptions="Center"
            VerticalOptions="CenterAndExpand" />
+        <Button Text="Here" Clicked="Button_Clicked"/>
     </StackLayout>
 
 </ContentPage>

--- a/PlayCoreUpdateTest/PlayCoreUpdateTest/MainPage.xaml.cs
+++ b/PlayCoreUpdateTest/PlayCoreUpdateTest/MainPage.xaml.cs
@@ -17,5 +17,11 @@ namespace PlayCoreUpdateTest
         {
             InitializeComponent();
         }
+
+        void Button_Clicked(Object sender, EventArgs e)
+        {
+            var appReviewer = DependencyService.Get<PlayCoreUpdateTest.IInAppReview>();
+            appReviewer.LaunchReview();
+        }
     }
 }


### PR DESCRIPTION
* Added a review button to the example
* Since you cannot see the In-App Review UI in the locally build and deployed app, I used similar code with my own bundle ID to deploy an app to "Internal app sharing" on the play store
* Was successfully able to see the screens shown
* Provides an example for the work done in #4, over the issue #2 
* Here's what it looks like:
<img width="705" alt="image" src="https://user-images.githubusercontent.com/8262287/93619419-8802e580-f9a6-11ea-9c80-920f8a3fb196.png">
